### PR TITLE
Get Django version from django.VERSION

### DIFF
--- a/nextpage/templatetags/nextpage.py
+++ b/nextpage/templatetags/nextpage.py
@@ -111,7 +111,7 @@ def paginate(context, template='pagination.html'):
 
         context = Context(to_return)
 
-        if django.get_version() >= '1.9':
+        if django.VERSION >= (1, 9):
             context = context.flatten()
 
     return template.render(context)


### PR DESCRIPTION
Get `Django` version from `django.VERSION`.
`django.get_version()` is not working properly since either `'1.10 > '1.8'` or `'1.10 > '1.9'` is `False`